### PR TITLE
refs #7264 - only check for java 1.7.0

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,14 +1,8 @@
 # Install Elasticsearch and dependencies
 class elasticsearch::install {
 
-  case $::operatingsystem {
-    'Fedora': {
-      $java_package = 'java-1.7.0-openjdk'
-    }
-    default: {
-      $java_package = 'java-1.6.0-openjdk'
-    }
-  }
+  $java_package = 'java-1.7.0-openjdk'
+
   package {['elasticsearch', $java_package]:
     ensure => 'installed'
   }


### PR DESCRIPTION
'yum install katello' will now pull in 1.7.0; therefore, without
this change, both 1.6.0 and 1.7.0 were getting installed on centos
and rhel.

Removing the 1.6.0 check since that is no longer needed.
